### PR TITLE
Use clang-format version 6 to ensure no diffs between newer and older…

### DIFF
--- a/diff_format.sh
+++ b/diff_format.sh
@@ -2,7 +2,7 @@
 OS_NAME=`uname -s | tr A-Z a-z`
 
 # Check if the first parameter is a flag starting with --. If so, that's
-# a flag we want to pass to clang-format. Shift the other parameters
+# a flag we want to pass to clang-format-6.0. Shift the other parameters
 # and continue.
 if [[ $1 =~ --.* ]]; then
   flag="$1"
@@ -14,7 +14,7 @@ for file in "$@"
 do
   echo -e "\n[Checking $file]"
   if [[ "$OS_NAME" != "darwin" ]]; then
-    diff --suppress-common-lines --color=always -u1 <(cat $file) <(clang-format $flag $file)
+    diff --suppress-common-lines --color=always -u1 <(cat $file) <(clang-format-6.0 $flag $file)
   else
     diff --suppress-common-lines -U1 <(cat $file) <(clang-format $flag $file)
   fi


### PR DESCRIPTION
Tested on Mac (clang-tidy fails but it was already failing?), CS50 and WSL.